### PR TITLE
Add explicitness to internal runaway Promise.all

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = (iterable, reducer, initVal) => new Promise((resolve, reject) =
 		Promise.all([total, el.value])
 			.then(value => {
 				next(reducer(value[0], value[1], i++));
+				return null;
 			})
 			.catch(reject);
 	};


### PR DESCRIPTION
Hello!

This is essentially a fix to avoid warnings in Promise libraries, like bluebird. 🐦 

It is obvious that you're being mindful in creating this runaway Promise, from the then handler, so being explicit about it removes the warnings.

Full details below.  
http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

Sidenote:  
Would be nice to add this as a test and also add that test to all your other p-* libs, but I'm unsure of how to do that. It would probably mean overriding `Promise` in all your tests? :(